### PR TITLE
Added keywords to the package.json so it shows up in search

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "author": "James R. Carr <james.r.carr@gmail.com> (http://blog.james-carr.org)",
   "name": "paynode",
   "description": "Module for integrating with various payment gateways",
+  "keywords": ["payment","gateway","paypal","chargify","braintree","authorize.net"],
   "version": "0.3.6",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Will allow paynode to show up when searching for the `paypal` keyword on the npm registry - https://npmjs.org/browse/keyword/paypal - among others.